### PR TITLE
Port versions 0.5.2, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.4 and 0.6.5

### DIFF
--- a/abstract_load_generator.py
+++ b/abstract_load_generator.py
@@ -1,9 +1,9 @@
 from abc import abstractmethod
 import shutil
 
-def cmd_exists(cmd):
+def cmd_exists(cmd, path=None):
     ''' Checks if a command exists'''
-    return shutil.which(cmd) is not None
+    return shutil.which(cmd, path=path) is not None
 
 class AbstractLoadGenerator:
     @abstractmethod

--- a/app_manager.py
+++ b/app_manager.py
@@ -1,4 +1,5 @@
 from configuration import ServiceMode
+from abstract_load_generator import cmd_exists
 import logging as log
 import subprocess
 import process_info

--- a/benchmarks/micronaut-hello-world/workloads/default.barista.json
+++ b/benchmarks/micronaut-hello-world/workloads/default.barista.json
@@ -21,7 +21,7 @@
             "iterations": 1,
             "iteration_time_seconds": 60,
             "search_strategy": "FIXED",
-            "rates": 15000
+            "rates": 10000
         }
     }
 }

--- a/concurrent_reader.py
+++ b/concurrent_reader.py
@@ -53,7 +53,7 @@ class ConcurrentReader(Thread):
         for line in iter(out.readline, b''):
             try:
                 line = line.decode()
-                print(line)
+                print(line, end="")
                 self._output += line
                 if not self._startup_times:
                     self._startup_times = extract_default_microservice_times(line)

--- a/configuration.py
+++ b/configuration.py
@@ -78,6 +78,7 @@ class Configuration:
         parser.add_argument("-s", "--lua-script", help="Lua script to be executed by wrk/wrk2 for general benchmarking purposes")
         parser.add_argument("--resource-usage-polling-interval", help="Time interval in seconds between two subsequent resource usage polls. Determines how often resource usage metrics, such as rss (Resident Set Size), vms (Virtual Memory Size), and CPU utilization, are collected. If set to 0 resource usage polling is disabled. Defaults to 0.02s (20ms)")
         parser.add_argument("--memory-refresh", action="store_true", help="Refresh the memory before running the application, ensuring cold system state. Flushes file system buffers, drops caches, and cycles swap space. Supported only on Linux. Requires sudo (root). Disabled by default.")
+        parser.add_argument("--ignore-deps-bin", action="store_true", help="By default, Barista prepends its 'deps/bin' directory to PATH when executing subprocesses to facilitate access to its dependencies. By setting this option, the behaviour will be disabled.")
         parser.add_argument("--skip-prepare", action="store_true", help="Explicitly skip the prepare step of the benchmark, even if a prepare script is present in the benchmark directory")
         parser.add_argument("--skip-cleanup", action="store_true", help="Explicitly skip the cleanup step of the benchmark, even if a cleanup script is present in the benchmark directory")
         parser.add_argument("-d", "--debug", action="store_true", help="Show debug logs")
@@ -283,6 +284,14 @@ class Configuration:
             polling_interval = 0.02 # 20 ms
             log.debug(f"No resource usage polling interval set. Defaulting to {polling_interval} seconds ({polling_interval * 1000}ms)")
         self._resource_usage_polling_interval = polling_interval
+
+        env = os.environ.copy()
+        ignore_deps_bin = self._args.ignore_deps_bin
+        if not ignore_deps_bin:
+            path = env.get("PATH", "")
+            deps_bin = os.path.join(os.path.dirname(__file__), "deps", "bin")
+            env["PATH"] = f"{deps_bin}:{path}" if path else deps_bin
+        self._env = env
 
         self._memory_refresh = self._args.memory_refresh
         self._skip_prepare = self._args.skip_prepare
@@ -691,6 +700,10 @@ class Configuration:
     @property
     def resource_usage_polling_interval(self):
         return self._resource_usage_polling_interval
+
+    @property
+    def env(self):
+        return self._env
 
     @property
     def memory_refresh(self):

--- a/configuration.py
+++ b/configuration.py
@@ -331,7 +331,7 @@ class Configuration:
             log.debug(f"No startup timeout set. Defaulting to {timeout} seconds")
 
         if self._args.startup_cmd_app_prefix is not None:
-            cmd_app_prefix = self._args.startup_cmd_app_prefix
+            cmd_app_prefix = self._args.startup_cmd_app_prefix.split()
         elif "cmd_app_prefix" in startup_config:
             cmd_app_prefix = startup_config["cmd_app_prefix"]
         else:

--- a/configuration.py
+++ b/configuration.py
@@ -77,6 +77,7 @@ class Configuration:
         parser.add_argument("-k", "--connections", help="Connections to keep open during the warmup, throughput and latency load-testing phases. This option can be overwritten for each of the mentioned phases. During each phase, the number of connections is propagated to wrk/wrk2.")
         parser.add_argument("-s", "--lua-script", help="Lua script to be executed by wrk/wrk2 for general benchmarking purposes")
         parser.add_argument("--resource-usage-polling-interval", help="Time interval in seconds between two subsequent resource usage polls. Determines how often resource usage metrics, such as rss (Resident Set Size), vms (Virtual Memory Size), and CPU utilization, are collected. If set to 0 resource usage polling is disabled. Defaults to 0.02s (20ms)")
+        parser.add_argument("--memory-refresh", action="store_true", help="Refresh the memory before running the application, ensuring cold system state. Flushes file system buffers, drops caches, and cycles swap space. Supported only on Linux. Requires sudo (root). Disabled by default.")
         parser.add_argument("--skip-prepare", action="store_true", help="Explicitly skip the prepare step of the benchmark, even if a prepare script is present in the benchmark directory")
         parser.add_argument("--skip-cleanup", action="store_true", help="Explicitly skip the cleanup step of the benchmark, even if a cleanup script is present in the benchmark directory")
         parser.add_argument("-d", "--debug", action="store_true", help="Show debug logs")
@@ -279,6 +280,7 @@ class Configuration:
             log.debug(f"No resource usage polling interval set. Defaulting to {polling_interval} seconds ({polling_interval * 1000}ms)")
         self._resource_usage_polling_interval = polling_interval
 
+        self._memory_refresh = self._args.memory_refresh
         self._skip_prepare = self._args.skip_prepare
         self._skip_cleanup = self._args.skip_cleanup
 
@@ -679,6 +681,10 @@ class Configuration:
     @property
     def resource_usage_polling_interval(self):
         return self._resource_usage_polling_interval
+
+    @property
+    def memory_refresh(self):
+        return self._memory_refresh
 
     @property
     def skip_prepare(self):

--- a/deps/bin/.gitignore
+++ b/deps/bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/deps/env.toml
+++ b/deps/env.toml
@@ -1,0 +1,28 @@
+[[dependencies]]
+type = "build"
+name = "wrk"
+check_command = ["wrk", "--help"]
+check_ret_code = 1
+build_cmds = [
+  "git clone https://github.com/wg/wrk .",
+  "git submodule update --init --recursive || true",
+  "make"
+]
+artifact_name = "wrk"
+dest_name = "wrk"
+
+[[dependencies]]
+type = "build"
+name = "wrk2"
+check_command = ["wrk2", "--help"]
+check_ret_code = 1
+check_output_function = """
+valid = "--rate" in stdout
+"""
+build_cmds = [
+  "git clone https://github.com/giltene/wrk2 .",
+  "git submodule update --init --recursive || true",
+  "make"
+]
+artifact_name = "wrk"
+dest_name = "wrk2"

--- a/deps/install.py
+++ b/deps/install.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python
+"""Installer for Barista dependencies.
+
+This script installs required CLI tools (e.g., wrk, wrk2) either by:
+- downloading prebuilt binaries (type="download"), or
+- building them from source (type="build").
+
+It reads a TOML environment file (deps/env*.toml), validates presence via
+user-provided or built-in checks, and installs into deps/bin.
+"""
+from __future__ import annotations
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Dict
+from collections.abc import Callable
+import subprocess
+import os
+import logging
+import sys
+import io
+import tempfile
+import shutil
+from contextlib import redirect_stdout, redirect_stderr
+import platform
+
+INSTALL_DIR = Path(__file__).absolute().parent / "bin" # barista/deps/bin
+REPO_ROOT = Path(__file__).absolute().parent.parent    # barista
+VENV_DIR = REPO_ROOT / "venv"                          # barista/venv
+VENV_BIN = VENV_DIR / "bin"                            # barista/venv/bin
+TMP_DIR = Path(__file__).absolute().parent / "tmp"     # barista/deps/tmp
+ENV = os.environ.copy()
+ENV["PATH"] = f"{VENV_BIN}:{INSTALL_DIR}:{ENV['PATH']}"
+
+def _normalize_os(name: str) -> str:
+    n = name.lower()
+    if n.startswith("linux"):
+        return "linux"
+    if n.startswith("darwin") or n.startswith("mac"):
+        return "darwin"
+    if n.startswith("win"):
+        return "windows"
+    if n.startswith("freebsd"):
+        return "freebsd"
+    return n
+
+def _normalize_arch(name: str) -> str:
+    n = name.lower()
+    if n in ("x86_64", "amd64"):
+        return "amd64"
+    if n in ("aarch64", "arm64"):
+        return "aarch64"
+    # keep common others as-is
+    return n
+
+def get_current_os_arch() -> tuple[str, str]:
+    """Return normalized (os, arch) for compatibility checks."""
+    return _normalize_os(platform.system()), _normalize_arch(platform.machine())
+
+def empty_dir_keep_gitignore(path: Path) -> None:
+    """Remove all entries under the given directory except a potential .gitignore, preserving the directory itself."""
+    path.mkdir(parents=True, exist_ok=True)
+    for p in path.iterdir():
+        if p.name == ".gitignore":
+            continue
+        if p.is_dir():
+            shutil.rmtree(p, ignore_errors=True)
+        else:
+            try:
+                p.unlink()
+            except FileNotFoundError:
+                pass
+
+@dataclass(frozen=True)
+class Dependency:
+    """Abstract dependency definition with health-check and installer hook."""
+
+    name: str
+    check_command: List[str]
+    check_ret_code: int
+    check_output_function: Optional[Callable[[str], bool]]
+
+    def check_and_maybe_install(self, force: bool) -> None:
+        """Install the dependency when forced or when the check fails; re-check after install."""
+        if force or not self.check_if_installed():
+            self.install()
+        if not self.check_if_installed():
+            raise ImportError(f"Failed to install '{self.name}' tool!")
+
+    def check_if_installed(self) -> bool:
+        try:
+            proc = subprocess.run(self.check_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=ENV)
+        except FileNotFoundError:
+            return False
+        if proc.returncode != self.check_ret_code:
+            return False
+        if self.check_output_function is not None and not self.check_output_function(proc.stdout.decode("utf-8")):
+            return False
+        return True
+
+    def install(self) -> None:
+        """Perform the installation of the dependency. Must be implemented by subclasses."""
+        raise NotImplementedError
+
+    @staticmethod
+    def create_check_output_function(name: str, code: Optional[str]) -> Optional[Callable[[str], bool]]:
+        """Create a validation function from a small Python snippet.
+
+        The snippet receives variables:
+          - stdout: str (captured stdout from check_command)
+          - valid: bool (must be set by the snippet)
+
+        Returns:
+            A callable that evaluates the snippet and returns True/False, or None if no snippet provided.
+        """
+        if not code:
+            return None
+        def check_output_function(stdout: str) -> bool:
+            locals = {"stdout": stdout, "valid": False}
+            logger = io.StringIO()
+            try:
+                with redirect_stdout(logger):
+                    with redirect_stderr(logger):
+                        exec(code, {}, locals)
+                        return locals["valid"]
+            except Exception as e:
+                logging.error(f"Error running user-defined check function for {name}: {e}")
+                return False
+        return check_output_function
+
+
+@dataclass(frozen=True)
+class DownloadableDependency(Dependency):
+    """Dependency that downloads a prebuilt archive and extracts the binary into INSTALL_DIR."""
+
+    archive_name: str
+    downloads_repo: str
+    install_dir: Path
+
+    def install(self) -> None:
+        """Download and extract the binary archive into INSTALL_DIR."""
+        cmd = f"curl -L {self.downloads_repo}/{self.name}/{self.archive_name} | tar -xz -C {self.install_dir} --wildcards --strip-components=1 */{self.name}"
+        logging.info(f"Installing '{self.name}' tool with command: '{cmd}'")
+        subprocess.run(cmd, shell=True)
+
+    @staticmethod
+    def from_dict(dependency: Dict) -> DownloadableDependency:
+        """Create a DownloadableDependency from a TOML-provided dictionary."""
+        name = dependency["name"]
+        return DownloadableDependency(
+            name=name,
+            check_command=dependency["check_command"],
+            check_ret_code=dependency["check_ret_code"],
+            check_output_function=Dependency.create_check_output_function(name, dependency.get("check_output_function")),
+            archive_name=dependency["archive_name"],
+            downloads_repo=dependency["repo"],
+            install_dir=INSTALL_DIR
+        )
+
+
+@dataclass(frozen=True)
+class BuildableDependency(Dependency):
+    """Dependency that is built from source via a sequence of shell commands."""
+
+    build_cmds: List[str]
+    artifact_name: str
+    dest_name: str
+    git_ref: Optional[str] = None
+
+    def install(self) -> None:
+        """Execute build_cmds in a temporary workdir, then copy the built artifact into INSTALL_DIR."""
+        logging.info(f"Installing '{self.name}' by building from source.")
+        INSTALL_DIR.mkdir(parents=True, exist_ok=True)
+        TMP_DIR.mkdir(parents=True, exist_ok=True)
+        temp_dir = Path(tempfile.mkdtemp(prefix=f"{self.name}-", dir=TMP_DIR))
+        success = False
+        try:
+            for cmd in self.build_cmds:
+                logging.info(f"Running command (cwd={temp_dir}): {cmd}")
+                result = subprocess.run(cmd, shell=True, cwd=temp_dir, env=ENV)
+                if result.returncode != 0:
+                    raise RuntimeError(f"Build command failed for {self.name}: {cmd}")
+            src = temp_dir / self.artifact_name
+            dest = INSTALL_DIR / self.dest_name
+            logging.info(f"Copying built artifact '{src}' to '{dest}'.")
+            if not src.exists():
+                raise FileNotFoundError(f"Built artifact not found for {self.name}: {src}")
+            shutil.copy2(src, dest)
+            dest.chmod(0o755)
+            success = True
+        finally:
+            # Preserve build directory on failure for diagnostics; remove on success unless overridden.
+            if success and "BARISTA_KEEP_BUILD_DIRS" not in os.environ:
+                try:
+                    shutil.rmtree(temp_dir)
+                except Exception:
+                    pass
+            else:
+                logging.info(f"Build directory preserved at {temp_dir}")
+
+    @staticmethod
+    def from_dict(dependency: Dict) -> 'BuildableDependency':
+        """Create a BuildableDependency from a TOML-provided dictionary."""
+        name = dependency["name"]
+        return BuildableDependency(
+            name=name,
+            check_command=dependency["check_command"],
+            check_ret_code=dependency["check_ret_code"],
+            check_output_function=Dependency.create_check_output_function(name, dependency.get("check_output_function")),
+            build_cmds=dependency.get("build_cmds"),
+            artifact_name=dependency.get("artifact_name"),
+            dest_name=dependency.get("dest_name", name),
+            git_ref=dependency.get("git_ref")
+        )
+
+
+def read_toml_file(toml_file_path: Path) -> Dict:
+    # tomllib was included in python standard library with version 3.11
+    try:
+        import tomllib
+        with open(toml_file_path, mode="rb") as f:
+            return tomllib.load(f)
+    except ImportError:
+        pass
+
+    # fallback to 'toml' library if tomllib is not present
+    try:
+        import toml
+        with open(toml_file_path, mode="rt") as f:
+            return toml.loads(f.read())
+    except ImportError:
+        logging.error(f"Could not read the {toml_file_path} toml file because there is no toml parser installed. Use python3.11+ or install `toml` with pip.")
+        raise
+
+
+def read_dependencies_from_env_file(env_file_path: Path) -> Dict[str, Dependency]:
+    """Parse an environment TOML file and build a mapping of dependency name -> Dependency instance."""
+    env_data = read_toml_file(env_file_path)
+    dependencies = {}
+    for dependency in env_data.get("dependencies", []):
+        dep_type = dependency["type"]
+        name = dependency["name"]
+        if dep_type == "download":
+            dependencies[name] = DownloadableDependency.from_dict(dependency)
+        elif dep_type == "build":
+            dependencies[name] = BuildableDependency.from_dict(dependency)
+        else:
+            raise ValueError(f"Unknown dependency of type '{dep_type}' encountered!")
+    return dependencies
+
+
+def read_env_file(env_file_path: Path) -> tuple[Dict[str, Dependency], Optional[Path], Optional[list[str]], Optional[list[str]]]:
+    """Read the env file and return (dependencies, fallback_path, supported_os, supported_arch).
+
+    Args:
+        env_file_path: Absolute path to the TOML environment file.
+
+    Returns:
+        A tuple containing:
+          - dict mapping dependency name to Dependency instance
+          - Optional absolute Path to a fallback env file, if defined
+          - Optional list of supported OS names
+          - Optional list of supported arch names
+    """
+    env_data = read_toml_file(env_file_path)
+
+    fallback_path: Optional[Path] = None
+    fallback_rel = env_data.get("fallback_env")
+    if fallback_rel:
+        # Treat fallback path as relative to repo root
+        fallback_path = (REPO_ROOT / fallback_rel).resolve()
+
+    supported_os = env_data.get("supported_os")
+    supported_arch = env_data.get("supported_arch")
+    # Normalize lists if present
+    if supported_os is not None:
+        supported_os = [_normalize_os(str(x)) for x in supported_os]
+    if supported_arch is not None:
+        supported_arch = [_normalize_arch(str(x)) for x in supported_arch]
+
+    deps: Dict[str, Dependency] = {}
+    for dependency in env_data.get("dependencies", []):
+        dep_type = dependency["type"]
+        name = dependency["name"]
+        if dep_type == "download":
+            deps[name] = DownloadableDependency.from_dict(dependency)
+        elif dep_type == "build":
+            deps[name] = BuildableDependency.from_dict(dependency)
+        else:
+            raise ValueError(f"Unknown dependency of type '{dep_type}' encountered in {env_file_path}!")
+    return deps, fallback_path, supported_os, supported_arch
+
+
+def main() -> None:
+    """CLI entry point for installing project dependencies."""
+    parser = ArgumentParser(prog="install", description="Installs missing (or all if forced) dependencies of the 'barista' project.")
+    parser.add_argument("--force", action="store_true", help="Force the installation of dependencies regardless of whether or not they are already installed. Cleans the installation (deps/bin) directory.")
+    parser.add_argument("--env-file", default="deps/env.toml", help="Path to environment TOML file.")
+    parser.add_argument("--no-fallback", action="store_true", help="Disable using fallback environments.")
+    args = vars(parser.parse_args())
+
+    env_file = Path(args["env_file"])
+    force = args["force"]
+    if not env_file.is_absolute():
+        env_file = (REPO_ROOT / env_file).resolve()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='[%(asctime)s] [%(levelname)s] %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        stream= sys.stdout
+    )
+
+    if force:
+        empty_dir_keep_gitignore(INSTALL_DIR)
+
+    visited: set[Path] = set()
+    current_env: Path = env_file
+    while True:
+        if current_env in visited:
+            raise RuntimeError(f"Fallback loop detected; env '{current_env}' has already been used: {visited}")
+        visited.add(current_env)
+
+        dependencies, fallback_path, supported_os, supported_arch = read_env_file(current_env)
+        try:
+            # Compatibility check
+            cur_os, cur_arch = get_current_os_arch()
+            compatible = True
+            if supported_os is not None and cur_os not in supported_os:
+                compatible = False
+            if supported_arch is not None and cur_arch not in supported_arch:
+                compatible = False
+            if not compatible:
+                raise Exception(f"Environment '{current_env}' not compatible with current system (os={cur_os}, arch={cur_arch}).")
+
+            # Dependency installation
+            for dependency in dependencies.values():
+                dependency.check_and_maybe_install(force)
+            break
+        except Exception as e:
+            if args.get("no_fallback", False):
+                raise
+            if not fallback_path or fallback_path in visited:
+                raise
+            if not compatible:
+                logging.warning(f"Environment '{current_env}' not compatible with current system (os={cur_os}, arch={cur_arch}). Trying fallback '{fallback_path}'.")
+            else:
+                logging.warning(f"Install failed using env '{current_env}': {e}. Trying fallback env '{fallback_path}'.")
+            current_env = fallback_path
+
+    logging.info("=================================================================")
+    logging.info("Finished installing Barista's dependencies!")
+    logging.info("=================================================================")
+
+
+if __name__ == "__main__":
+    main()

--- a/deps/tmp/.gitignore
+++ b/deps/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/load_tester.py
+++ b/load_tester.py
@@ -7,8 +7,6 @@ Each one of these periods is highly configurable.
 
 from wrk2_load_generator import Wrk2LoadGenerator
 from wrk1_load_generator import Wrk1LoadGenerator
-from abstract_load_generator import cmd_exists
-import subprocess
 import os
 import logging as log
 import traceback
@@ -32,9 +30,9 @@ class Benchmark:
         #Change this for throughput measures
         self._output_folder = self._config.output_folder
         self._startup_manager = StartupManager(self._config)
-        self._warmup = Wrk1LoadGenerator(self._config._warmup, self._output_folder, self._config.endpoint)
-        self._latency_benchmark = Wrk2LoadGenerator(self._config.latency, self._output_folder, self._config.endpoint)
-        self._throughput_benchmark = Wrk1LoadGenerator(self._config.throughput, self._output_folder, self._config.endpoint)
+        self._warmup = Wrk1LoadGenerator(self._config._warmup, self._output_folder, self._config.endpoint, self._config.env)
+        self._latency_benchmark = Wrk2LoadGenerator(self._config.latency, self._output_folder, self._config.endpoint, self._config.env)
+        self._throughput_benchmark = Wrk1LoadGenerator(self._config.throughput, self._output_folder, self._config.endpoint, self._config.env)
         self._app_output = ""
         self._concurrent_reader = None
         self._results = None
@@ -115,7 +113,7 @@ class Benchmark:
 
     def _run_latency(self, throughput_data):
         """Execute the latency phase of the benchmark."""
-        latency_manager = ThroughputExplorer(self.config.latency, self._output_folder, self.config.endpoint, throughput_data)
+        latency_manager = ThroughputExplorer(self.config.latency, self._output_folder, self.config.endpoint, throughput_data, self.config.env)
         results = latency_manager.explore()
         return results
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barista"
-version = "0.6.3"
+version = "0.6.4"
 description = "A benchmark suite for JVM microservices"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barista"
-version = "0.6.0"
+version = "0.6.1"
 description = "A benchmark suite for JVM microservices"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barista"
-version = "0.5.2"
+version = "0.6.0"
 description = "A benchmark suite for JVM microservices"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barista"
-version = "0.5.1"
+version = "0.5.2"
 description = "A benchmark suite for JVM microservices"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barista"
-version = "0.6.1"
+version = "0.6.2"
 description = "A benchmark suite for JVM microservices"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barista"
-version = "0.6.2"
+version = "0.6.3"
 description = "A benchmark suite for JVM microservices"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "barista"
-version = "0.6.4"
+version = "0.6.5"
 description = "A benchmark suite for JVM microservices"
 readme = "README.md"
 classifiers = [

--- a/startup_manager.py
+++ b/startup_manager.py
@@ -38,13 +38,13 @@ class StartupManager:
         """Runs the startup phase of the benchmark process."""
         for iteration_idx in range(self.config.startup.iteration_count):
             log.info(f"Running startup phase iteration #{iteration_idx + 1}")
-            self.app_manager.start_app(self.config.startup.cmd_app_prefix, self.config.startup.cmd_app_prefix_init_sleep, True)
+            self.app_manager.start_app(self.config.startup.cmd_app_prefix, self.config.startup.cmd_app_prefix_init_sleep, self.config.startup.dummy_run_after_memory_refresh, True)
             iteration_data = self._run_single_startup_iteration()
             self.kill_app()
             self._iterations.append(iteration_data)
         self._aggregate_iteration_data()
 
-        self.app_manager.start_app(self.config.cmd_app_prefix, self.config.cmd_app_prefix_init_sleep)
+        self.app_manager.start_app(self.config.cmd_app_prefix, self.config.cmd_app_prefix_init_sleep, self.config.dummy_run_after_memory_refresh)
         app_process = self.app_manager.app_process
         log.info(f"Detected app process (pid={app_process.pid}) with command-line:\n{' '.join(app_process.cmdline())}")
         self._run_single_startup_iteration()

--- a/startup_manager.py
+++ b/startup_manager.py
@@ -93,9 +93,9 @@ class StartupManager:
                 if res.status < 500:
                     log.debug(f"App responded {res.status} after startup")
                     break
-                else :
+                else:
                     log.warning(f"App responded {res.status}. Stopping and cleaning up")
-                    self._cleanup()
+                    self.kill_app()
             except ConnectionRefusedError:
                 ts_current = time.perf_counter()
                 if ts_current - ts_last_poll >= poll_interval:

--- a/tests/test_install_deps.py
+++ b/tests/test_install_deps.py
@@ -1,0 +1,144 @@
+"""Pytest to verify installing dependencies defined by environment files in deps.
+
+This test:
+- Discovers all environment files matching deps/env*.toml
+- Runs the installer for each env, forcing installation of wrk and wrk2
+- Verifies that wrk and wrk2 are present and that --help behaves as expected
+- Cleans deps/bin and deps/tmp between runs and after the test to avoid residue
+"""
+import logging
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+# Discover environment files automatically (any deps/env*.toml)
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENV_FILES = sorted([p for p in (REPO_ROOT / "deps").glob("env*.toml") if p.is_file()])
+
+
+def _empty_dir_keep_gitignore(path: Path) -> None:
+    """
+    Remove all entries under the given directory except a potential .gitignore, preserving the directory itself.
+    Throws an exception if not called on a subdirectory of the `deps` directory in the repo's root.
+    """
+    # Ensure this function is called for a subdirectory of the `deps` directory
+    repo_root = Path(__file__).resolve().parent.parent
+    deps_dir = repo_root / "deps"
+    if deps_dir not in path.parents:
+        raise ValueError(f"Unsafe deletion of directory attempted! Only deletions of subdirectories of the 'deps' directory are allowed for security reasons! Attempt was made to delete '{path}'!")
+    # Proceed with deletion
+    path.mkdir(parents=True, exist_ok=True)
+    for p in path.iterdir():
+        if p.name == ".gitignore":
+            continue
+        if p.is_dir():
+            shutil.rmtree(p, ignore_errors=True)
+        else:
+            try:
+                p.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _verify_tools(bin_dir: Path) -> None:
+    """Validate that wrk and wrk2 are present and respond to --help appropriately."""
+    wrk = bin_dir / "wrk"
+    wrk2 = bin_dir / "wrk2"
+
+    assert wrk.exists() and wrk.is_file(), f"Missing wrk at {wrk}"
+    assert wrk2.exists() and wrk2.is_file(), f"Missing wrk2 at {wrk2}"
+
+    for tool_path in (wrk, wrk2):
+        # Accept return codes 0 or 1 for --help
+        proc = subprocess.run(
+            [str(tool_path), "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        logging.info("'%s --help' rc=%s", tool_path.name, proc.returncode)
+        logging.info(proc.stdout.decode("utf-8", errors="replace"))
+        assert proc.returncode in (0, 1), f"{tool_path.name} --help returned {proc.returncode}"
+
+    # wrk2 help should include --rate option
+    proc_wrk2 = subprocess.run(
+        [str(wrk2), "--help"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    out_wrk2 = proc_wrk2.stdout.decode("utf-8", errors="replace")
+    assert "--rate" in out_wrk2, "wrk2 --help output does not contain --rate"
+
+
+
+
+def _run_install_for_env(repo_root: Path, env_file: Path) -> None:
+    """Run the installer for the given env file, forcing installs of wrk and wrk2."""
+    logging.info("Running deps/install.py for env: %s", env_file)
+    # Force install to ensure we exercise both paths (download/build)
+    subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "deps" / "install.py"),
+            "--env-file",
+            str(env_file),
+            "--force",
+            "--no-fallback",
+        ],
+        check=True,
+    )
+    logging.info("deps/install.py executed successfully for %s", env_file)
+
+
+@pytest.fixture(scope="module")
+def repo_paths() -> Dict[str, Path]:
+    """Return common repository paths used by the tests."""
+    # tests/ is one level below repo root
+    repo_root = Path(__file__).resolve().parent.parent
+    deps_dir = repo_root / "deps"
+    bin_dir = deps_dir / "bin"
+    tmp_dir = deps_dir / "tmp"
+    return {
+        "repo_root": repo_root,
+        "deps_dir": deps_dir,
+        "bin_dir": bin_dir,
+        "tmp_dir": tmp_dir,
+    }
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test(repo_paths: Dict[str, Path]) -> None:
+    """Cleanup fixture that empties deps/bin and deps/tmp after each test execution."""
+    # Nothing before the test; we will clean between envs and after module
+    yield
+    # Final cleanup: empty deps/bin and deps/tmp to avoid leaving artifacts
+    _empty_dir_keep_gitignore(repo_paths["bin_dir"])
+    _empty_dir_keep_gitignore(repo_paths["tmp_dir"])
+
+
+@pytest.mark.parametrize("env_file", ENV_FILES)
+def test_install_dependencies(repo_paths: Dict[str, Path], env_file: Path) -> None:
+    """Install dependencies for a discovered env file and validate wrk and wrk2."""
+    bin_dir: Path = repo_paths["bin_dir"]
+    tmp_dir: Path = repo_paths["tmp_dir"]
+    repo_root: Path = repo_paths["repo_root"]
+
+
+    logging.info("=" * 50)
+    logging.info("Testing environment file: %s", env_file)
+    logging.info("=" * 50)
+
+    # Clean before running each env to ensure isolation
+    _empty_dir_keep_gitignore(bin_dir)
+    _empty_dir_keep_gitignore(tmp_dir)
+
+    try:
+        _run_install_for_env(repo_root, env_file)
+    except subprocess.CalledProcessError as e:
+        pytest.skip(f"Installer failed for {env_file} (rc={e.returncode}); likely environment/network issue.")
+    _verify_tools(bin_dir)

--- a/throughput_explorer.py
+++ b/throughput_explorer.py
@@ -10,12 +10,13 @@ FIXED_PERCENTAGE = 'FIXED_PERCENTAGE'
 
 class ThroughputExplorer():
 
-    def __init__(self, latency_config, output_dir, endpoint, throughput_result):
+    def __init__(self, latency_config, output_dir, endpoint, throughput_result, env):
         self._latency_config = latency_config
         self._throughput = throughput_result
         self._output_dir = output_dir
         self._endpoint = endpoint
         self._counter = 0
+        self._env = env
 
         self.find_avg_throughput()
 
@@ -51,7 +52,7 @@ class ThroughputExplorer():
         if mode_name == FIXED_PERCENTAGE:
             measure_rate = rate[0]
             name = rate[1]
-        latency_load_gen = Wrk2LoadGenerator(self._latency_config, self._output_dir, self._endpoint)
+        latency_load_gen = Wrk2LoadGenerator(self._latency_config, self._output_dir, self._endpoint, self._env)
         log.info(f"Now measuring the latency for {mode_name} mode at {measure_rate} for {self._latency_config.iteration_count} iterations")
 
         latency_results = []
@@ -219,7 +220,7 @@ class ThroughputExplorer():
         log.info(f"Performing short measurement of {measurment_duration_s}s for determining next optimal rate")
         request_rate = int(expected_rate_percentage * self._avg)
 
-        latency_benchmark = Wrk2LoadGenerator(self._latency_config, self._output_dir, self._endpoint)
+        latency_benchmark = Wrk2LoadGenerator(self._latency_config, self._output_dir, self._endpoint, self._env)
         results = latency_benchmark.measure(request_rate, measurment_duration_s)
         latency_benchmark.dump_stdout(self._output_dir, results['stdout'], f"latency-adjustment-{self._counter+1}")
         self._counter += 1

--- a/wrk2_load_generator.py
+++ b/wrk2_load_generator.py
@@ -17,8 +17,12 @@ class Wrk2LoadGenerator(AbstractWrkLoadGenerator):
         if not cmd_exists("wrk2"):
             raise FileNotFoundError("wrk2 command not found please set it in PATH.")
 
-        if not self.wrk2_has_rate():
-            raise FileNotFoundError("wrk2 should have --rate flag. Please ensure you have wrk2 alias not for wrk")
+        has_rate, version_output = self.wrk2_has_rate()
+        if not has_rate:
+            raise FileNotFoundError(
+                "wrk2 should have --rate flag. Please ensure you have wrk2 alias not for wrk.\n"
+                f"Output of 'wrk2 --version':\n{version_output}"
+            )
 
         if duration is None:
             duration = self._config.iteration_duration
@@ -54,10 +58,10 @@ class Wrk2LoadGenerator(AbstractWrkLoadGenerator):
         log.debug("no cleanup needed for wrk2 load generator")
 
     def wrk2_has_rate(self):
-        wrk = subprocess.Popen(['wrk2', '--version'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell = False)
+        wrk = subprocess.Popen(['wrk2', '--version'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
         wrk.wait()
         output = wrk.communicate()[0].decode("utf-8")
-        return '--rate' in output
+        return ('--rate' in output, output)
 
     def parse_latencies(self, output):
         latency = " *(\d+\.?\d*)% +(\d+\.?\d*)(\w+)"


### PR DESCRIPTION
This PR contains 7 commits, each one corresponding to a version bump:
* 0.5.2: Lower the latency rate of the default workload for Micronaut Hello World to accommodate slower configurations.
* 0.6.0: Allow for more accurate cold-system-state startup measurements by optionally clearing cache between iterations.
  * Optionally clear cache between startup iterations.
    * This option is disabled by default.
    * This option is only supported on Linux.
    * This option requires sudo access!
  * Impact on Micronaut Hello World ran as a native image (just some sample numbers for illustration, impact will obviously vary across benchmarks/systems/hardware):
    * Without the new --memory-refresh option (behaviour on master; default behaviour) startup is 14.40ms.
    * With the new `--memory-refresh` option startup is 103.53ms.
      * This is the more accurate cold-system-state startup number.
  * Bug fix: Don't add line-breaks to app output (which normally already contains its own line-breaks).
* 0.6.1: Dynamically find all active swap devices/files.
  * Prevent barista to crash when using `--memory-refresh` on machines and containers that have no `/etc/fstab` file.
  * To solve this issue, this commit enhances `_memory_refresh` to dynamically detect and cycle all currently active swap devices/files by parsing `/proc/swaps`. Unlike the previous approach using `swapoff/swapon -a` and hence the `/etc/fstab` file, this ensures that swaps activated outside of `/etc/fstab` are also turned off and back on, providing more complete and reliable memory refresh.
* 0.6.2: Store startup cmd app prefix as an array.
  * Bug fix: Store `--startup-cmd-app-prefix` as an array and not as a string.
* 0.6.3: Add dummy run after memory refresh options.
  * This change prevents side effects (including page faults) caused by the command prefix from being measured during benchmark execution.
  * To achieve this, the command prefix is now run prior to the start of the benchmark.
  * This behaviour can be enabled generally using `--dummy-run-after-memory-refresh` or just for the startup iterations using `--startup-dummy-run-after-memory-refresh`.
* 0.6.4: Show wrk2 version output in case of invalid or malfunctioning binary.
  * This improves the error message in case of a problem with `wrk2` execution.
* 0.6.5: Add dependency installer to facilitate automatic installs.
  * Add the installer for Barista dependencies: `deps/install.py`
    * The installer itself is not aware of the required dependencies nor the steps necessary for their installation.
    * The installer knows how to handle `download` and `build` type dependencies.
    * The dependencies and the steps are given in an environment file - the environment file is like a recipe that the installer follows.
      * Environment file `deps/env.toml` prescribes cloning the source repositories of `wrk` and `wrk2` and building the tools from source.
    * An environment file can be arch/OS restricted - the installer will ensure these requirements are met by the running system.
    * The installer has the ability to retry the installation with a different environment if the previous environment fails.
    * The installer will install the dependencies to the `deps/bin` directory.
  * Add `--ignore-deps-bin` option to disable the prepending of the dependency installation directory when executing Barista subprocesses. This directory is now prepended for subprocesses by default, to facilitate the usage of dependencies installed by the installer.
  * Add a test for the installer in `tests/test_install_deps.py`.